### PR TITLE
In draftv4, we can skip required parameter of missing property.

### DIFF
--- a/lib/Valiemon/Attributes/Properties.pm
+++ b/lib/Valiemon/Attributes/Properties.pm
@@ -32,8 +32,9 @@ sub is_valid {
                     $data->{$prop} = clone($default);
                     # in case default value applied, skip validation for default value
                     next;
-                } elsif ($definition->{required}) {
-                    # if required specified and default not exists, it's invalid
+                } elsif ($context->prims->is_boolean($definition->{required}) && $definition->{required}) {
+                    # if {required: true} specified and default not exists, it's invalid(draftv3).
+                    # if {required: [properties]} specified, just skip it(draftv4).
                     # TODO check definition. Is it valid existing "default" and "required" in same property???
                     $is_valid=0;
                     last;


### PR DESCRIPTION
This pull request checks a type of `required` parameter and makes invalid only if the value is boolean and it is true.

- in draftv3: required is a boolean property.
  - https://github.com/Julian/jsonschema/blob/afada1cfaa70104f7d0117fef035468011b43f2d/jsonschema/schemas/draft3.json#L170
- in draftv4: required is a stringArray.
  - https://github.com/Julian/jsonschema/blob/afada1cfaa70104f7d0117fef035468011b43f2d/jsonschema/schemas/draft4.json#L195